### PR TITLE
Exceptions now being sent back to publisher

### DIFF
--- a/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
+++ b/src/main/scala/org/zalando/react/nakadi/NakadiActorPublisher.scala
@@ -2,7 +2,6 @@ package org.zalando.react.nakadi
 
 import akka.stream.actor.ActorPublisher
 import akka.actor.{ActorLogging, ActorRef, PoisonPill, Props}
-
 import org.zalando.react.nakadi.commit.OffsetMap
 import org.zalando.react.nakadi.LeaseManagerActor.Flush
 import org.zalando.react.nakadi.client.models.EventStreamBatch
@@ -11,6 +10,7 @@ import org.zalando.react.nakadi.NakadiActorPublisher.CommitOffsets
 import org.zalando.react.nakadi.NakadiMessages.{Offset, StringConsumerMessage}
 
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 
 object NakadiActorPublisher {
@@ -52,6 +52,7 @@ class NakadiActorPublisher(consumerAndProps: ReactiveNakadiConsumer, leaseManage
     case Cancel                                           => stop()
     case NakadiActorPublisher.Stop                        => stop()
     case CommitOffsets(offsetMap)                         => executeCommit(offsetMap)
+    case NonFatal(err)                                    => onError(err)
   }
 
   private def registerSupervisor(ref: ActorRef) = {

--- a/src/main/scala/org/zalando/react/nakadi/client/providers/Events.scala
+++ b/src/main/scala/org/zalando/react/nakadi/client/providers/Events.scala
@@ -104,7 +104,7 @@ class ConsumeEvents(properties: ConsumerProperties,
       onInitMessage = Init,
       ackMessage = Acknowledge,
       onCompleteMessage = Complete,
-      onFailureMessage = x => x
+      onFailureMessage = receiverActorRef ! _
     )
 
     val consumer = Flow[HttpResponse].mapAsync(1) {


### PR DESCRIPTION
Allow the consuming Nakadi `Source` to be able to handle errors that may occur. For example:

```scala
Source
  .watchTermination() { (_, fut) =>
    fut.recover {
      case err => println(s"recover error: $err")
    }
  }
  .fromPublisher(publisher)
  .map(someProcessingOfMessage)
  .to(Sink.fromSubscriber(subscriber))
  .run()
```